### PR TITLE
Ejemplo de un esquema basado en Data Package

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -1,0 +1,88 @@
+{
+  "profile": "tabular-data-package",
+  "resources": [
+    {
+      "name": "diputados_congreso_union",
+      "path": "http://sitl.diputados.gob.mx/LXIV_leg/listado_diputados_gpnp.php?tipot=TOTAL",
+      "profile": "tabular-data-resource",
+      "schema": {
+        "fields": [
+          {
+            "name": "id",
+            "type": "integer",
+            "format": "default",
+            "title": "id",
+            "description": "identificado único"
+          },
+          {
+            "name": "nombre",
+            "type": "string",
+            "format": "default",
+            "title": "nombre",
+            "description": "nombre completo de la persona"
+          },
+          {
+            "name": "entidad",
+            "type": "string",
+            "format": "default",
+            "title": "entidad",
+            "description": "estado al que representa"
+          },
+          {
+            "name": "distrito",
+            "type": "string",
+            "format": "default",
+            "title": "distrito",
+            "description": "distrito o circunscripción\n"
+          },
+          {
+            "name": "partido",
+            "type": "string",
+            "format": "default",
+            "title": "partido",
+            "description": "partido al que pertenece"
+          },
+          {
+            "name": "correo_electronico",
+            "type": "string",
+            "format": "email",
+            "title": "correo_electronico",
+            "description": "correo oficial"
+          },
+          {
+            "name": "telefono",
+            "type": "string",
+            "format": "default",
+            "title": "telefono",
+            "description": "número de teléfono oficial"
+          }
+        ]
+      },
+      "title": "Diputados",
+      "format": "csv",
+      "encoding": "utf-8"
+    }
+  ],
+  "keywords": [
+    "datos legislativos",
+    "diputados"
+  ],
+  "name": "datos_legislativos",
+  "title": "Estándar de datos legislativos",
+  "description": "Estándar de datos abiertos legislativos",
+  "homepage": "http://sitl.diputados.gob.mx/LXIV_leg/listado_diputados_gpnp.php?tipot=TOTAL",
+  "version": "1.0.0",
+  "contributors": [
+    {
+      "title": "Codeando México",
+      "role": "author"
+    }
+  ],
+  "licenses": [
+    {
+      "name": "CC-BY-4.0",
+      "title": "Creative Commons Attribution 4.0",
+      "path": "https://creativecommons.org/licenses/by/4.0/"
+    }
+  ]
+}


### PR DESCRIPTION
Este es un ejemplo de cómo definir el esquema para un paquete de datos (ejemplo para el listado de diputados) utilizando el schema que define Frictionless en su [Data Package](https://specs.frictionlessdata.io/data-package/).

Algunas de las consideraciones son:

- Para crear un _data package_ se declara un esquema basándose en las reglas de [Table Schema](https://specs.frictionlessdata.io/table-schema/#language) para datos tabulares. 
- Este esquema se expresa en formato JSON que sigue las especificaciones de [JSON Schema](https://specs.frictionlessdata.io/schemas/table-schema.json).
- El _data package_ te permite incluir metadatos como licencia, palabras clave, autores, etc.
- Se puede validar utilizando las [herramientas](https://frictionlessdata.io/standards/#standards-toolkit) de Frictionless data.

Relacionado al issue #70 